### PR TITLE
Notification permission examples

### DIFF
--- a/sql/notification-permissions-origin-form-factor.sql
+++ b/sql/notification-permissions-origin-form-factor.sql
@@ -1,0 +1,29 @@
+#standardSQL
+# Notification permission response rates for multiple origins and form factors.
+SELECT
+  origin,
+  form_factor,
+  ROUND(accept / total, 4) AS accept,
+  ROUND(deny / total, 4) AS deny,
+  ROUND(`ignore` / total, 4) AS `ignore`,
+  ROUND(dismiss / total, 4) AS dismiss
+FROM (
+  SELECT
+    origin,
+    form_factor.name AS form_factor,
+    SUM(experimental.permission.notifications.accept) AS accept,
+    SUM(experimental.permission.notifications.deny) AS deny,
+    SUM(experimental.permission.notifications.ignore) AS `ignore`,
+    SUM(experimental.permission.notifications.dismiss) AS dismiss,
+    SUM(experimental.permission.notifications.accept +
+        experimental.permission.notifications.deny +
+        experimental.permission.notifications.ignore +
+        experimental.permission.notifications.dismiss) AS total
+  FROM
+    `chrome-ux-report.all.202001`
+  WHERE
+    origin IN ('https://mobile.twitter.com', 'https://twitter.com') AND
+    experimental.permission.notifications IS NOT NULL
+  GROUP BY
+    origin,
+    form_factor)

--- a/sql/notification-permissions.sql
+++ b/sql/notification-permissions.sql
@@ -1,0 +1,11 @@
+#standardSQL
+# Explore notification permission response rates.
+SELECT
+  SUM(experimental.permission.notifications.accept) AS accept,
+  SUM(experimental.permission.notifications.deny) AS deny,
+  SUM(experimental.permission.notifications.ignore) AS `ignore`,
+  SUM(experimental.permission.notifications.dismiss) AS dismiss
+FROM
+  `chrome-ux-report.all.202001`
+WHERE
+  origin = 'https://news.google.com'

--- a/sql/p75-fcp.sql
+++ b/sql/p75-fcp.sql
@@ -1,0 +1,18 @@
+#standardSQL
+# Approximates the 75th percentile FCP for a given origin and form factor.
+SELECT
+  MIN(start) AS fcp
+FROM (
+  SELECT
+      fcp.start as start,
+      fcp.density AS density,
+      SUM(fcp.density) OVER (ORDER BY fcp.start) / SUM(fcp.density) OVER () AS total
+  FROM
+    `chrome-ux-report.all.202001`,
+    UNNEST(first_contentful_paint.histogram.bin) AS fcp
+  WHERE
+    origin = 'https://www.example.com' AND
+    form_factor.name = 'phone')
+WHERE
+  # 0.75 = 75th percentile
+  total >= 0.75


### PR DESCRIPTION
Notification permissions:
- aggregate rates for a given origin
- per-form-factor rates for multiple origins

FCP:
- approximating the 75th percentile