### PR TITLE
Make FID optional and add CWV 2024 calculation.

### DIFF
--- a/sql/core-web-vitals-compliance-rates.sql
+++ b/sql/core-web-vitals-compliance-rates.sql
@@ -1,6 +1,6 @@
 #standardSQL
-# This query processes 735.9 MB.
 # Calculate the percent of origins that comply with each Core Web Vital's "good" threshold for 75% or more of experiences.
+# The pct_good_cwv_2024 calculation reflects INP replacing FID in 2024 (see https://web.dev/blog/inp-cwv-march-12)>
 
 CREATE TEMP FUNCTION IS_GOOD (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
   good / (good + needs_improvement + poor) >= 0.75
@@ -10,6 +10,9 @@ CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor 
   good + needs_improvement + poor > 0
 );
 
+CREATE TEMP FUNCTION IS_MISSING (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+  good is NULL and needs_improvement is NULL and poor is NULL
+);
 
 SELECT
   SAFE_DIVIDE(
@@ -21,22 +24,36 @@ SELECT
     COUNT(DISTINCT IF(IS_GOOD(fast_fid, avg_fid, slow_fid), origin, NULL)),
     COUNT(DISTINCT IF(IS_NON_ZERO(fast_fid, avg_fid, slow_fid), origin, NULL))) AS pct_good_fid,
 
+  # Origins with good FID divided by origins with any INP.
+  SAFE_DIVIDE(
+    COUNT(DISTINCT IF(IS_GOOD(fast_inp, avg_inp, slow_inp), origin, NULL)),
+    COUNT(DISTINCT IF(IS_NON_ZERO(fast_inp, avg_inp, slow_inp), origin, NULL))) AS pct_good_inp,
+
   # Origins with good CLS divided by origins with any CLS.
   SAFE_DIVIDE(
     COUNT(DISTINCT IF(IS_GOOD(small_cls, medium_cls, large_cls), origin, NULL)),
     COUNT(DISTINCT IF(IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS pct_good_cls,
 
-  # Origins with good LCP, FID, and CLS dividied by origins with any LCP, FID, and CLS.
+  # Origins with good LCP, FID (optional), and CLS dividied by origins with any LCP and CLS.
   SAFE_DIVIDE(
     COUNT(DISTINCT IF(
       IS_GOOD(fast_lcp, avg_lcp, slow_lcp) AND
-      IS_GOOD(fast_fid, avg_fid, slow_fid) AND
+      (IS_GOOD(fast_fid, avg_fid, slow_fid) OR IS_MISSING(fast_fid, avg_fid, slow_fid)) AND
       IS_GOOD(small_cls, medium_cls, large_cls), origin, NULL)),
     COUNT(DISTINCT IF(
       IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp) AND
-      IS_NON_ZERO(fast_fid, avg_fid, slow_fid) AND
-      IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS pct_good_cwv
+      IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS pct_good_cwv,
+
+  # Origins with good LCP, INP (optional), and CLS dividied by origins with any LCP and CLS.
+  SAFE_DIVIDE(
+    COUNT(DISTINCT IF(
+      IS_GOOD(fast_lcp, avg_lcp, slow_lcp) AND
+      (IS_GOOD(fast_inp, avg_inp, slow_inp) OR IS_MISSING(fast_inp, avg_inp, slow_inp)) AND
+      IS_GOOD(small_cls, medium_cls, large_cls), origin, NULL)),
+    COUNT(DISTINCT IF(
+      IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp) AND
+      IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS pct_good_cwv_2024
 FROM
   `chrome-ux-report.materialized.metrics_summary`
 WHERE
-  date = '2020-08-01'
+  date = '2024-01-01'


### PR DESCRIPTION
Thanks to Fili Wiese for pointing out the discrepancies in our CrUX 202401 data release announcement. This should fix the script.